### PR TITLE
Add SaaS detail page monorepo scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install CMS deps
+        run: |
+          cd cms && npm install
+      - name: Install Frontend deps
+        run: |
+          cd frontend && npm install
+      - name: Build Frontend
+        run: |
+          cd frontend && npm run build
+      - name: Deploy Frontend to Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: frontend
+          vercel-args: '--prod'
+      - name: Restart Docker Compose services
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            cd /path/to/app && docker-compose pull && docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Detail_Page
+# AI Product Detail Page Platform
+
+This monorepo contains a Strapi CMS, Next.js frontend, n8n orchestrator and infrastructure for an AI powered product detail page SaaS.
+
+## Setup
+
+```bash
+npm install # or yarn install in each package
+```
+
+```bash
+docker-compose -f infra/docker-compose.yml up --build
+```
+
+### Adding a new template in GrapesJS
+1. Log in to the Strapi admin panel at `/cms/admin`.
+2. Open the GrapesJS editor field and save your template JSON under the `htmlBuilder` field.
+
+### Triggering AI Generation
+- Create a new Product entry in Strapi. The n8n workflow will automatically generate copy and images using OpenAI and update the entry.
+- You can also click the **AI Generate** button on a product page which calls `/api/generate` to trigger generation manually.

--- a/cms/config/plugins.js
+++ b/cms/config/plugins.js
@@ -1,0 +1,8 @@
+module.exports = {
+  'grapesjs-editor': {
+    enabled: true,
+    config: {
+      // Plugin default configuration
+    }
+  }
+};

--- a/cms/package.json
+++ b/cms/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cms",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "develop": "strapi develop",
+    "start": "strapi start",
+    "build": "strapi build"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "dependencies": {
+    "@strapi/strapi": "^4.17.0",
+    "@rs-pk/strapi-grapesjs-editor": "^1.0.7",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/cms/src/api/product/content-types/product/schema.json
+++ b/cms/src/api/product/content-types/product/schema.json
@@ -1,0 +1,38 @@
+{
+  "kind": "collectionType",
+  "collectionName": "products",
+  "info": {
+    "singularName": "product",
+    "pluralName": "products",
+    "displayName": "Product"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    },
+    "heroSlogan": {
+      "type": "string"
+    },
+    "problemText": {
+      "type": "text"
+    },
+    "solutionText": {
+      "type": "text"
+    },
+    "featureImages": {
+      "type": "media",
+      "multiple": true
+    },
+    "htmlBuilder": {
+      "type": "json"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/frontend/pages/api/generate.js
+++ b/frontend/pages/api/generate.js
@@ -1,0 +1,6 @@
+export default async function handler(req, res) {
+  const { id } = req.query;
+  // call orchestrator or local service
+  // placeholder implementation
+  res.status(200).json({ message: `Triggered AI generation for ${id}` });
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">Product List</h1>
+      {/* Product list placeholder */}
+    </div>
+  );
+}

--- a/frontend/pages/products/[slug].js
+++ b/frontend/pages/products/[slug].js
@@ -1,0 +1,41 @@
+import { useRouter } from 'next/router'
+
+export default function Product({ product }) {
+  const router = useRouter();
+  if (router.isFallback) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-4">{product.name}</h1>
+      <div dangerouslySetInnerHTML={{ __html: product.html }} />
+      <button className="mt-4 px-4 py-2 bg-blue-500 text-white" onClick={() => fetch('/api/generate?id=' + product.id)}>
+        AI Generate
+      </button>
+    </div>
+  );
+}
+
+export async function getStaticPaths() {
+  const res = await fetch(process.env.NEXT_PUBLIC_CMS_URL + '/api/products');
+  const data = await res.json();
+  const paths = data.data.map(p => ({ params: { slug: p.attributes.slug } }));
+  return { paths, fallback: true };
+}
+
+export async function getStaticProps({ params }) {
+  const res = await fetch(process.env.NEXT_PUBLIC_CMS_URL + `/api/products?filters[slug][$eq]=${params.slug}&populate=*`);
+  const data = await res.json();
+  const item = data.data[0];
+  return {
+    props: {
+      product: {
+        id: item.id,
+        ...item.attributes,
+        html: item.attributes.htmlBuilder?.html || ''
+      }
+    },
+    revalidate: 60
+  };
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './pages/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,10 @@
+# OpenAI
+OPENAI_API_KEY=your-openai-key
+
+# Cloudinary
+CLOUDINARY_CLOUD_NAME=your-cloud
+CLOUDINARY_API_KEY=your-key
+CLOUDINARY_API_SECRET=your-secret
+
+# Strapi
+STRAPI_ADMIN_JWT_SECRET=your-strapi-secret

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+services:
+  cms:
+    build: ../cms
+    env_file: .env
+    ports:
+      - "1337:1337"
+    volumes:
+      - ../cms:/app
+  orchestrator:
+    image: n8nio/n8n
+    env_file: .env
+    ports:
+      - "5678:5678"
+    volumes:
+      - ../orchestrator:/home/node/.n8n
+  frontend:
+    build: ../frontend
+    env_file: .env
+    ports:
+      - "3000:3000"
+    command: "npm run start"
+    volumes:
+      - ../frontend:/app
+  proxy:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    location /cms/ {
+        proxy_pass http://cms:1337/;
+    }
+    location /n8n/ {
+        proxy_pass http://orchestrator:5678/;
+    }
+    location / {
+        proxy_pass http://frontend:3000/;
+    }
+}

--- a/orchestrator/workflow.json
+++ b/orchestrator/workflow.json
@@ -1,0 +1,128 @@
+{
+  "nodes": [
+    {
+      "id": "webhook",
+      "type": "webhook",
+      "parameters": {
+        "path": "new-product",
+        "method": "POST"
+      },
+      "name": "Strapi Webhook"
+    },
+    {
+      "id": "openai-chat",
+      "type": "httpRequest",
+      "name": "OpenAI Chat",
+      "parameters": {
+        "url": "https://api.openai.com/v1/chat/completions",
+        "method": "POST",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "Authorization": "Bearer {{ $env.OPENAI_API_KEY }}"
+        },
+        "bodyParameters": {
+          "model": "gpt-3.5-turbo",
+          "messages": [
+            {"role": "system", "content": "You are a copywriter"},
+            {"role": "user", "content": "Generate product copy"}
+          ]
+        }
+      }
+    },
+    {
+      "id": "openai-image",
+      "type": "httpRequest",
+      "name": "OpenAI Image",
+      "parameters": {
+        "url": "https://api.openai.com/v1/images/generations",
+        "method": "POST",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "Authorization": "Bearer {{ $env.OPENAI_API_KEY }}"
+        },
+        "bodyParameters": {
+          "prompt": "feature illustration"
+        }
+      }
+    },
+    {
+      "id": "upload-cloudinary",
+      "type": "httpRequest",
+      "name": "Upload Cloudinary",
+      "parameters": {
+        "url": "https://api.cloudinary.com/v1_1/{{ $env.CLOUDINARY_CLOUD_NAME }}/image/upload",
+        "method": "POST",
+        "queryParameters": {
+          "api_key": "{{ $env.CLOUDINARY_API_KEY }}",
+          "timestamp": "{{ Date.now() }}",
+          "signature": "{{ $env.CLOUDINARY_API_SECRET }}"
+        },
+        "bodyParameters": {
+          "file": "={{ $json[\"url\"] }}"
+        }
+      }
+    },
+    {
+      "id": "update-strapi",
+      "type": "httpRequest",
+      "name": "Update Strapi",
+      "parameters": {
+        "url": "http://cms:1337/api/products/{{ $node[\"webhook\"].json.body.id }}",
+        "method": "PUT",
+        "authentication": "headerAuth",
+        "headerParameters": {
+          "Authorization": "Bearer {{ $env.STRAPI_ADMIN_JWT_SECRET }}"
+        },
+        "bodyParameters": {
+          "data": {
+            "problemText": "={{ $node[\"openai-chat\"].json.choices[0].message.content }}",
+            "solutionText": "Generated solution",
+            "featureImages": ["={{ $node[\"upload-cloudinary\"].json.secure_url }}"]
+          }
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Strapi Webhook": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Chat",
+            "type": "main"
+          }
+        ]
+      ]
+    },
+    "OpenAI Chat": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Image",
+            "type": "main"
+          }
+        ]
+      ]
+    },
+    "OpenAI Image": {
+      "main": [
+        [
+          {
+            "node": "Upload Cloudinary",
+            "type": "main"
+          }
+        ]
+      ]
+    },
+    "Upload Cloudinary": {
+      "main": [
+        [
+          {
+            "node": "Update Strapi",
+            "type": "main"
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold CMS with Strapi v4 and GrapesJS editor
- scaffold Next.js frontend with TailwindCSS
- add n8n workflow orchestrator
- provide docker-compose infrastructure and example env file
- add CI workflow for building and deploying
- document setup in README

## Testing
- `tree -L 2 -I '.git'`


------
https://chatgpt.com/codex/tasks/task_e_68636dcf29d08329bd631a940941392a